### PR TITLE
CrankNicolson for OpenFOAM 2.3.0

### DIFF
--- a/laminarVortexShedding/system/fvSchemes
+++ b/laminarVortexShedding/system/fvSchemes
@@ -18,7 +18,7 @@ FoamFile
 ddtSchemes
 {
     //default         Euler;
-    default         CrankNicholson 0.5;
+    default         CrankNicolson 0.5;
 //  OF 2.3.x and later versions    
 //  default         CrankNicolson 0.5;
 }


### PR DESCRIPTION
Hello and thank you for the excellent tutorial!  I just wanted to let you know that the simulation will not run in OpenFOAM 2.3.0 unless line 21 in fvSchemes is changed to

"default             CrankNicolson 0.5;
